### PR TITLE
feat: Make scikit-learn an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@
 as logistic regression with stochastic gradient descent
 (see [Elo as Logistic Regression](intro.md) for a walkthrough)
 to offer a collection of extensions to the rating system.
-All models are `narwhals`
-(for dataframe libraries with [full API support](https://narwhals-dev.github.io/narwhals/))
-and `scikit-learn` compatible.
+All rating systems are `narwhals` compatible for dataframe libraries with 
+[full API support](https://narwhals-dev.github.io/narwhals/).
 
 ## :sparkles: Features
 
 - Standard Elo rating system for binary outcomes.
-    - `narwhals` and `scikit-learn` compatible.
-    - Does not support draws.
+    - `narwhals` compatible.
+    - A `scikit-learn` compatible implementation is available in the `sklearn` submodule.
     - See [`examples/nba.ipynb`](https://github.com/cookepm/elo-grad/blob/main/examples/nba.ipynb) for an example using NBA data and `polars`.
 - Elo rating system for binary outcomes with additional regressors, *e.g.* home advantage.
     - L1 and L2 regularisation supported for additional regressors (see [Regularisation](https://cookepm.github.io/elo-grad/feature_ref/regularisation/)). 
     - See [Additional Regressors](https://cookepm.github.io/elo-grad/feature_ref/additional_regressors/) for the theory and [`examples/nba.ipynb`](https://github.com/cookepm/elo-grad/blob/main/examples/nba.ipynb) for an example using NBA data and `polars`.
 - Elo rating system for count data based on Poisson regression.
-    - `narwhals` and `scikit-learn` compatible.
+    - `narwhals` compatible.
+    - A `scikit-learn` compatible implementation is available in the `sklearn` submodule.
     - See [Poisson Elo](https://cookepm.github.io/elo-grad/feature_ref/poisson.md) for the theory and [`examples/football.ipynb`](https://github.com/cookepm/elo-grad/blob/main/examples/football.ipynb) for an example using Premier League football data and `pandas`.
 
 ## :book: Installation
@@ -29,6 +29,10 @@ and `scikit-learn` compatible.
 You can install `elo-grad` with:
 ```bash
 pip install elo-grad
+```
+For the `scikit-learn` compatible rating systems, the `sklearn` optional dependencies must be installed as:
+```bash
+pip install elo-grad[sklearn]
 ```
 
 ## :zap: Quick Start

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,21 +7,21 @@
 as logistic regression with stochastic gradient descent
 (see [Elo as Logistic Regression](intro.md) for a walkthrough)
 to offer a collection of extensions to the rating system.
-All models are `narwhals`
-(for dataframe libraries with [full API support](https://narwhals-dev.github.io/narwhals/))
-and `scikit-learn` compatible.
+All rating systems are `narwhals` compatible for dataframe libraries with 
+[full API support](https://narwhals-dev.github.io/narwhals/).
 
 ## :sparkles: Features
 
 - Standard Elo rating system for binary outcomes.
-    - `narwhals` and `scikit-learn` compatible.
-    - Does not support draws.
+    - `narwhals` compatible.
+    - A `scikit-learn` compatible implementation is available in the `sklearn` submodule.
     - See [`examples/nba.ipynb`](https://github.com/cookepm/elo-grad/blob/main/examples/nba.ipynb) for an example using NBA data and `polars`.
 - Elo rating system for binary outcomes with additional regressors, *e.g.* home advantage.
     - L1 and L2 regularisation supported for additional regressors (see [Regularisation](feature_ref/regularisation/)).
     - See [Additional Regressors](feature_ref/additional_regressors.md) for the theory and [`examples/nba.ipynb`](https://github.com/cookepm/elo-grad/blob/main/examples/nba.ipynb) for an example using NBA data and `polars`.
 - Elo rating system for count data based on Poisson regression.
-    - `narwhals` and `scikit-learn` compatible.
+    - `narwhals` compatible.
+    - A `scikit-learn` compatible implementation is available in the `sklearn` submodule.
     - See [Poisson Elo](feature_ref/poisson.md) for the theory and [`examples/football.ipynb`](https://github.com/cookepm/elo-grad/blob/main/examples/football.ipynb) for an example using Premier League football data and `pandas`.
 
 ## :book: Installation
@@ -29,6 +29,10 @@ and `scikit-learn` compatible.
 You can install `elo-grad` with:
 ```bash
 pip install elo-grad
+```
+For the `scikit-learn` compatible rating systems, the `sklearn` optional dependencies must be installed as:
+```bash
+pip install elo-grad[sklearn]
 ```
 
 ## :zap: Quick Start

--- a/examples/football.ipynb
+++ b/examples/football.ipynb
@@ -49,6 +49,7 @@
     "from sklearn.model_selection import GridSearchCV, TimeSeriesSplit\n",
     "\n",
     "from elo_grad import PoissonEloEstimator, Regressor\n",
+    "from elo_grad.sklearn import SKPoissonEloEstimator\n",
     "\n",
     "\n",
     "print(f'Python {sys.version} on {sys.platform}.')"
@@ -88,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -232,7 +233,7 @@
        "2016-08-13       1       1  1471046400        4      D  "
       ]
      },
-     "execution_count": 18,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -270,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -289,7 +290,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -310,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -419,7 +420,7 @@
        "2016-08-13     Crystal Palace - Defence     0      1  "
       ]
      },
-     "execution_count": 20,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -482,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,14 +510,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "23.5 ms ± 2.98 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
+      "25.5 ms ± 4.37 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
      ]
     }
    ],
@@ -543,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -561,7 +562,7 @@
        " ('Chelsea - Defence', (1640822400, 1561.4380200053079))]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -590,7 +591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -636,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -664,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -823,7 +824,7 @@
        "2022-01-02             0.925730  "
       ]
      },
-     "execution_count": 31,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -843,7 +844,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -875,7 +876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -899,7 +900,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -928,7 +929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -965,7 +966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1012,12 +1013,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As our estimator is `scikit-learn` compatible, we can use `scikit-learn` to do things like perform a grid search over hyper-parameters."
+    "`elo-grad` also offers the `scikit-learn` estimator `SKPoissonEloEstimator`.\n",
+    "We can then use `scikit-learn` to do things like perform a grid search over hyper-parameters."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1059,10 +1061,10 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0.015675</td>\n",
-       "      <td>0.001517</td>\n",
-       "      <td>0.010583</td>\n",
-       "      <td>0.003257</td>\n",
+       "      <td>0.010790</td>\n",
+       "      <td>0.002983</td>\n",
+       "      <td>0.008532</td>\n",
+       "      <td>0.002570</td>\n",
        "      <td>200</td>\n",
        "      <td>10</td>\n",
        "      <td>{'beta': 200, 'k_factor': 10}</td>\n",
@@ -1075,10 +1077,10 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.011816</td>\n",
-       "      <td>0.003495</td>\n",
-       "      <td>0.008834</td>\n",
-       "      <td>0.002392</td>\n",
+       "      <td>0.011184</td>\n",
+       "      <td>0.004232</td>\n",
+       "      <td>0.008122</td>\n",
+       "      <td>0.001213</td>\n",
        "      <td>200</td>\n",
        "      <td>50</td>\n",
        "      <td>{'beta': 200, 'k_factor': 50}</td>\n",
@@ -1095,8 +1097,8 @@
       ],
       "text/plain": [
        "   mean_fit_time  std_fit_time  mean_score_time  std_score_time  param_beta  \\\n",
-       "0       0.015675      0.001517         0.010583        0.003257         200   \n",
-       "1       0.011816      0.003495         0.008834        0.002392         200   \n",
+       "0       0.010790      0.002983         0.008532        0.002570         200   \n",
+       "1       0.011184      0.004232         0.008122        0.001213         200   \n",
        "\n",
        "   param_k_factor                         params  split0_test_score  \\\n",
        "0              10  {'beta': 200, 'k_factor': 10}           1.163245   \n",
@@ -1111,14 +1113,14 @@
        "1                1  "
       ]
      },
-     "execution_count": 37,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "gs = GridSearchCV(\n",
-    "    estimator=PoissonEloEstimator(entity_cols=('team', 'opponent'), score_col='score'), \n",
+    "    estimator=SKPoissonEloEstimator(entity_cols=('team', 'opponent'), score_col='score'), \n",
     "    param_grid={\n",
     "        'beta': [200],\n",
     "        'k_factor': [10, 50],\n",
@@ -1146,7 +1148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1164,7 +1166,7 @@
        " ('Liverpool - Defence', (1640736000, 1567.1180981942805))]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1197,7 +1199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1216,7 +1218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1389,7 +1391,7 @@
        "2022-01-02             0.925730               0.951970               0.999832  "
       ]
      },
-     "execution_count": 41,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1409,7 +1411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1445,7 +1447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -1490,7 +1492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1519,14 +1521,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "44.9 ms ± 6.71 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
+      "37.7 ms ± 3.24 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
      ]
     }
    ],

--- a/examples/nba.ipynb
+++ b/examples/nba.ipynb
@@ -40,6 +40,7 @@
     "from sklearn.model_selection import GridSearchCV, TimeSeriesSplit\n",
     "\n",
     "from elo_grad import EloEstimator, Regressor\n",
+    "from elo_grad.sklearn import SKEloEstimator\n",
     "\n",
     "\n",
     "print(f'Python {sys.version} on {sys.platform}.')"
@@ -292,7 +293,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's do a performance benchmark."
+    "Let's do a performance benchmark for our lightweight estimator `EloEstimator`."
    ]
   },
   {
@@ -304,7 +305,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "299 ms ± 8.78 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
+      "311 ms ± 17 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
      ]
     }
    ],
@@ -465,7 +466,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As our estimator is `scikit-learn` compatible, we can use `scikit-learn` to do things like perform a grid search over hyper-parameters."
+    "`elo-grad` also offers the `scikit-learn` estimator `SKEloEstimator`.\n",
+    "We can then use `scikit-learn` to do things like perform a grid search over hyper-parameters."
    ]
   },
   {
@@ -491,7 +493,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (2, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>mean_fit_time</th><th>std_fit_time</th><th>mean_score_time</th><th>std_score_time</th><th>param_beta</th><th>param_k_factor</th><th>params</th><th>split0_test_score</th><th>split1_test_score</th><th>split2_test_score</th><th>mean_test_score</th><th>std_test_score</th><th>rank_test_score</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td><td>i64</td><td>struct[2]</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>i32</td></tr></thead><tbody><tr><td>0.279005</td><td>0.008425</td><td>0.112189</td><td>0.019831</td><td>200</td><td>10</td><td>{200,10}</td><td>0.640402</td><td>0.632654</td><td>0.636501</td><td>0.636519</td><td>0.003163</td><td>2</td></tr><tr><td>0.21795</td><td>0.120991</td><td>0.124444</td><td>0.035428</td><td>200</td><td>100</td><td>{200,100}</td><td>0.694953</td><td>0.676101</td><td>0.679805</td><td>0.683619</td><td>0.008155</td><td>1</td></tr></tbody></table></div>"
+       "<small>shape: (2, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>mean_fit_time</th><th>std_fit_time</th><th>mean_score_time</th><th>std_score_time</th><th>param_beta</th><th>param_k_factor</th><th>params</th><th>split0_test_score</th><th>split1_test_score</th><th>split2_test_score</th><th>mean_test_score</th><th>std_test_score</th><th>rank_test_score</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td><td>i64</td><td>struct[2]</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>i32</td></tr></thead><tbody><tr><td>0.200956</td><td>0.032989</td><td>0.081744</td><td>0.002181</td><td>200</td><td>10</td><td>{200,10}</td><td>0.640402</td><td>0.632654</td><td>0.636501</td><td>0.636519</td><td>0.003163</td><td>2</td></tr><tr><td>0.155675</td><td>0.060365</td><td>0.083358</td><td>0.003495</td><td>200</td><td>100</td><td>{200,100}</td><td>0.694953</td><td>0.676101</td><td>0.679805</td><td>0.683619</td><td>0.008155</td><td>1</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (2, 13)\n",
@@ -501,8 +503,8 @@
        "│ ---       ┆ ---       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ ---       ┆ ---      │\n",
        "│ f64       ┆ f64       ┆ f64       ┆ f64       ┆   ┆ f64       ┆ f64       ┆ f64       ┆ i32      │\n",
        "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
-       "│ 0.279005  ┆ 0.008425  ┆ 0.112189  ┆ 0.019831  ┆ … ┆ 0.636501  ┆ 0.636519  ┆ 0.003163  ┆ 2        │\n",
-       "│ 0.21795   ┆ 0.120991  ┆ 0.124444  ┆ 0.035428  ┆ … ┆ 0.679805  ┆ 0.683619  ┆ 0.008155  ┆ 1        │\n",
+       "│ 0.200956  ┆ 0.032989  ┆ 0.081744  ┆ 0.002181  ┆ … ┆ 0.636501  ┆ 0.636519  ┆ 0.003163  ┆ 2        │\n",
+       "│ 0.155675  ┆ 0.060365  ┆ 0.083358  ┆ 0.003495  ┆ … ┆ 0.679805  ┆ 0.683619  ┆ 0.008155  ┆ 1        │\n",
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
       ]
      },
@@ -513,7 +515,7 @@
    ],
    "source": [
     "gs = GridSearchCV(\n",
-    "    estimator=EloEstimator(entity_cols=('team1', 'team2'), score_col='result'), \n",
+    "    estimator=SKEloEstimator(entity_cols=('team1', 'team2'), score_col='result'), \n",
     "    param_grid={\n",
     "        'beta': [200],\n",
     "        'k_factor': [10, 100],\n",
@@ -650,7 +652,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "598 ms ± 112 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
+      "573 ms ± 94.5 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
      ]
     }
    ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "narwhals>=1.14.0",
-    "scikit-learn>=1.5.2",
 ]
 
 [project.optional-dependencies]
@@ -23,6 +22,9 @@ examples = [
 ]
 plot = [
     "matplotlib>=3.9.2",
+]
+sklearn = [
+    "scikit-learn>=1.5.2",
 ]
 
 [build-system]

--- a/src/elo_grad/sklearn.py
+++ b/src/elo_grad/sklearn.py
@@ -1,0 +1,314 @@
+import abc
+from typing import Optional, Dict, Tuple, List, Callable
+
+from sklearn.base import BaseEstimator
+from sklearn.metrics import mean_poisson_deviance, log_loss
+
+from elo_grad import EloEstimator, PoissonEloEstimator, Regressor, ClassifierRatingSystemMixin, RegressionRatingSystemMixin
+
+__all__ = [
+    "SKEloEstimator",
+    "SKPoissonEloEstimator",
+]
+
+
+class SKRatingSystemMixin(abc.ABC):
+
+    @abc.abstractmethod
+    def score(self, X, y, sample_weight=None): ...
+
+    def _more_tags(self):
+        return {"requires_y": False}
+
+
+class SKClassifierRatingSystemMixin(ClassifierRatingSystemMixin, SKRatingSystemMixin):
+    """
+    Mixin class for classification rating systems.
+
+    This mixin defines the following functionality:
+
+    - `_estimator_type` class attribute defaulting to `"classifier"`;
+    - `score` method that default to :func:`~sklearn.metrics.log_loss`.
+    - enforce that `fit` does not require `y` to be passed through the `requires_y` tag.
+    """
+
+    _estimator_type = "classifier"
+    classes_ = [[0, 1]]
+
+    def score(self, X, y, sample_weight=None):
+        """
+        Return the log-loss on the given test data and labels.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Test samples.
+
+        y : array-like of shape (n_samples,) or (n_samples, n_outputs)
+            True labels for `X`.
+
+        sample_weight : array-like of shape (n_samples,), default=None
+            Sample weights.
+
+        Returns
+        -------
+        score : float
+            Log-loss of ``self.predict_proba(X)[:, 1]`` w.r.t. `y`.
+        """
+        return log_loss(
+            y, self.predict_proba(X)[:, 1], sample_weight=sample_weight
+        )
+
+
+class SKRegressionRatingSystemMixin(RegressionRatingSystemMixin, SKRatingSystemMixin):
+    """
+    Mixin class for regression rating systems.
+
+    This mixin defines the following functionality:
+
+    - `_estimator_type` class attribute defaulting to `"regressor"`;
+    - `score` method that default to :func:`~sklearn.metrics.mean_poisson_deviance`.
+    - enforce that `fit` does not require `y` to be passed through the `requires_y` tag.
+    """
+
+    _estimator_type = "regressor"
+
+    def score(self, X, y, sample_weight=None):
+        """
+        Return the mean Poisson deviance on the given test data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Test samples.
+
+        y : array-like of shape (n_samples,) or (n_samples, n_outputs)
+            True labels for `X`.
+
+        sample_weight : array-like of shape (n_samples,), default=None
+            Sample weights.
+
+        Returns
+        -------
+        score : float
+            Mean Poisson deviance of ``self.predict(X)`` w.r.t. `y`.
+        """
+        return mean_poisson_deviance(
+            y, self.predict(X), sample_weight=sample_weight
+        )
+
+
+class SKBaseEstimator(BaseEstimator):
+    @staticmethod
+    def _reinitialize_dec(method: Callable):
+        """
+        Decorator to reinitialize the rating system after parameter changes.
+        Helpful when performing a grid search.
+
+        Parameters
+        ----------
+        method : Callable
+            Method to decorate
+        """
+
+        def wrapper(self, **params):
+            result = method(self, **params)
+            self.reinitialize()
+
+            return result
+
+        return wrapper
+
+    @_reinitialize_dec
+    def set_params(self, **params):
+        return super().set_params(**params)
+
+
+class SKEloEstimator(SKClassifierRatingSystemMixin, EloEstimator, SKBaseEstimator):
+    """
+    Scikit-learn compatible Elo rating system classifier.
+
+    Attributes
+    ----------
+    beta : float
+        Normalization factor for ratings when computing expected score.
+    columns : List[str]
+        [entity_1, entity_2, result] columns names.
+    default_init_rating : float
+        Default initial rating for entities.
+    entity_cols : Tuple[str, str]
+        Names of columns identifying the names of the entities playing the games.
+    init_ratings : Optional[Dict[str, Tuple[Optional[int], float]]]
+        Initial ratings for entities (dictionary of form entity: (Unix timestamp, rating))
+    k_factor : float
+        Elo K-factor/step-size for gradient descent.
+    model : Model
+        Underlying statistical model.
+    optimizer : Optimizer
+        Optimizer to update the model.
+    rating_history : List[Tuple[Optional[int], float]]
+        Historical ratings of entities (if track_rating_history is True).
+    score_col : str
+        Name of score column (1 if entity_1 wins and 0 if entity_2 wins).
+        Draws are not currently supported.
+    date_col : str
+        Name of date column, which has Unix timestamp (in seconds) of the
+        game.
+    additional_regressors : Optional[List[Regressor]]
+        Additional regressors to include, e.g. home advantage.
+    track_rating_history : bool
+        Flag to track historical ratings of entities.
+
+    Methods
+    -------
+    fit(X, y=None)
+        Fit Elo rating system/calculate ratings.
+    record_ratings()
+        Record the current ratings of entities.
+    predict_proba(X)
+        Produce probability estimates.
+    predict(X)
+        Predict outcome of game.
+    """
+
+    def __init__(
+        self,
+        k_factor: float = 20,
+        default_init_rating: float = 1200,
+        beta: float = 200,
+        init_ratings: Optional[Dict[str, Tuple[Optional[int], float]]] = None,
+        entity_cols: Tuple[str, str] = ("entity_1", "entity_2"),
+        score_col: str = "score",
+        date_col: str = "t",
+        additional_regressors: Optional[List[Regressor]] = None,
+        track_rating_history: bool = False,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        k_factor : float
+            Elo K-factor/step-size for gradient descent for the entities.
+        default_init_rating : float
+            Default initial rating for entities.
+        beta : float
+            Normalization factor for ratings when computing expected score.
+        init_ratings : Optional[Dict[str, Tuple[Optional[int], float]]]
+            Initial ratings for entities (dictionary of form entity: (Unix timestamp, rating))
+        entity_cols : Tuple[str, str]
+            Names of columns identifying the names of the entities playing the games.
+        score_col : str
+            Name of score column (1 if entity_1 wins and 0 if entity_2 wins).
+            Draws are not currently supported.
+        date_col : str
+            Name of date column, which has Unix timestamp (in seconds) of the
+            game.
+        additional_regressors : Optional[List[Regressor]]
+            Additional regressors to include, e.g. home advantage.
+        track_rating_history : bool
+            Flag to track historical ratings of entities.
+        """
+        super().__init__(
+            k_factor=k_factor,
+            default_init_rating=default_init_rating,
+            beta=beta,
+            init_ratings=init_ratings,
+            entity_cols=entity_cols,
+            score_col=score_col,
+            date_col=date_col,
+            additional_regressors=additional_regressors,
+            track_rating_history=track_rating_history,
+        )
+
+
+class SKPoissonEloEstimator(SKRegressionRatingSystemMixin, PoissonEloEstimator, SKBaseEstimator):
+    """
+    Scikit-learn compatible Poisson Elo rating system.
+
+    Attributes
+    ----------
+    beta : float
+        Normalization factor for ratings when computing expected score.
+    columns : List[str]
+        [entity_1, entity_2, result] columns names.
+    default_init_rating : float
+        Default initial rating for entities.
+    entity_cols : Tuple[str, str]
+        Names of columns identifying the names of the entities playing the games.
+    init_ratings : Optional[Dict[str, Tuple[Optional[int], float]]]
+        Initial ratings for entities (dictionary of form entity: (Unix timestamp, rating))
+    k_factor : float
+        Elo K-factor/step-size for gradient descent.
+    model : Model
+        Underlying statistical model.
+    optimizer : Optimizer
+        Optimizer to update the model.
+    rating_history : List[Tuple[Optional[int], float]]
+        Historical ratings of entities (if track_rating_history is True).
+    score_col : str
+        Name of score column (1 if entity_1 wins and 0 if entity_2 wins).
+        Draws are not currently supported.
+    date_col : str
+        Name of date column, which has Unix timestamp (in seconds) of the
+        game.
+    additional_regressors : Optional[List[Regressor]]
+        Additional regressors to include, e.g. home advantage.
+    track_rating_history : bool
+        Flag to track historical ratings of entities.
+
+    Methods
+    -------
+    fit(X, y=None)
+        Fit Elo rating system/calculate ratings.
+    record_ratings()
+        Record the current ratings of entities.
+    predict(X)
+        Predict score.
+    """
+
+    def __init__(
+        self,
+        k_factor: float = 20,
+        default_init_rating: float = 1200,
+        beta: float = 200,
+        init_ratings: Optional[Dict[str, Tuple[Optional[int], float]]] = None,
+        entity_cols: Tuple[str, str] = ("entity_1", "entity_2"),
+        score_col: str = "score",
+        date_col: str = "t",
+        additional_regressors: Optional[List[Regressor]] = None,
+        track_rating_history: bool = False,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        k_factor : float
+            Elo K-factor/step-size for gradient descent for the entities.
+        default_init_rating : float
+            Default initial rating for entities.
+        beta : float
+            Normalization factor for ratings when computing expected score.
+        init_ratings : Optional[Dict[str, Tuple[Optional[int], float]]]
+            Initial ratings for entities (dictionary of form entity: (Unix timestamp, rating))
+        entity_cols : Tuple[str, str]
+            Names of columns identifying the names of the entities playing the games.
+        score_col : str
+            Name of score column (1 if entity_1 wins and 0 if entity_2 wins).
+            Draws are not currently supported.
+        date_col : str
+            Name of date column, which has Unix timestamp (in seconds) of the
+            game.
+        additional_regressors : Optional[List[Regressor]]
+            Additional regressors to include, e.g. home advantage.
+        track_rating_history : bool
+            Flag to track historical ratings of entities.
+        """
+        super().__init__(
+            k_factor=k_factor,
+            default_init_rating=default_init_rating,
+            beta=beta,
+            init_ratings=init_ratings,
+            entity_cols=entity_cols,
+            score_col=score_col,
+            date_col=date_col,
+            additional_regressors=additional_regressors,
+            track_rating_history=track_rating_history,
+        )


### PR DESCRIPTION
As many use cases will not require full scikit-learn compatibility and scikit-learn is sizeable dependency, we default to ratings which are not fully scikit-learn compatible and have no dependency on scikit-learn.

Fully scikit-learn compatible ratings systems are still offered via the sklearn submodule and optional sklearn dependency group.