### PR TITLE
docs: Update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In rough order, things we want to add are:
 - Interaction terms
 - Other optimizers, e.g. momentum
 - Extend plotting support, e.g. plotly
-- Support for handling correlation in scores
+- Support hierarchical matches, e.g. tennis matches with sets and games
 - Explore any ways we can approximate standard errors for the ratings
 
 ## :blue_book: References

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,7 +80,7 @@ In rough order, things we want to add are:
 - Interaction terms
 - Other optimizers, e.g. momentum
 - Extend plotting support, e.g. plotly
-- Support for handling correlation in scores
+- Support hierarchical matches, e.g. tennis matches with sets and games
 - Explore any ways we can approximate standard errors for the ratings
 
 ## :blue_book: References


### PR DESCRIPTION
Remove plan to handle correlation in scores. This is outside the scope of the rating systems or can potentially be handled by an appropriate choice of rating system, e.g. a Skellam rating system rather than two Poisson systems.

We replace this with a plan to support hierarchical matches, such as tennis which has sets and games within a match. This would allow us to pass a dataframe at the match level but fit a rating system at the set or game level. We could also roll the predictions back to the match level.