### PR TITLE
feat: Bivariate ratings

### DIFF
--- a/src/elo_grad/__init__.py
+++ b/src/elo_grad/__init__.py
@@ -57,22 +57,25 @@ class Regressor:
 
 class BaseModel(abc.ABC):
 
+    def __init__(self, beta: float) -> None:
+        self.beta: float = beta
+
+
+class UnivariateModel(BaseModel, abc.ABC):
+
     def __init__(
         self,
         beta: float,
         default_init_rating: float,
         init_ratings: Optional[Dict[str, Tuple[Optional[int], float]]] = None,
     ) -> None:
-        self.beta: float = beta
+        super().__init__(beta)
+        self.init_ratings: Optional[Dict[str, Tuple[Optional[int], float]]] = init_ratings
         self.ratings: Dict[str, Tuple[Optional[int], float]] = defaultdict(
             lambda: (None, default_init_rating)
         )
-        self.init_ratings: Optional[Dict[str, Tuple[Optional[int], float]]] = init_ratings
         if self.init_ratings is not None:
             self.ratings = self.ratings | self.init_ratings
-
-
-class UnivariateModel(BaseModel, abc.ABC):
 
     @abc.abstractmethod
     def calculate_gradient(self, y: int, *args) -> float:

--- a/src/elo_grad/bivariate.py
+++ b/src/elo_grad/bivariate.py
@@ -1,12 +1,28 @@
 import abc
+from collections import defaultdict
+
 import math
 from functools import lru_cache
-from typing import Tuple, Optional, Generator
+from typing import Tuple, Optional, Generator, Dict
 
 from . import BaseModel, Regressor
 
 
 class BivariateModel(BaseModel, abc.ABC):
+
+    def __init__(
+        self,
+        beta: float,
+        default_init_rating: Tuple[float, float],
+        init_ratings: Optional[Dict[str, Tuple[Optional[int], float, Optional[float]]]] = None,
+    ) -> None:
+        super().__init__(beta)
+        self.init_ratings: Optional[Dict[str, Tuple[Optional[int], float, Optional[float]]]] = init_ratings
+        self.ratings: Dict[str, Tuple[Optional[int], float, Optional[float]]] = defaultdict(  # type:ignore
+            lambda: (None, *default_init_rating)
+        )
+        if self.init_ratings is not None:
+            self.ratings = self.ratings | self.init_ratings
 
     @abc.abstractmethod
     def calculate_params(self, *args) -> Tuple[float, ...]:


### PR DESCRIPTION
Allow ratings to take form (Unix timestamp, attacking rating, defensive rating) for bivariate ratings.