### PR TITLE
chore: Explicitly typing in elo_grad.bivariate

### DIFF
--- a/src/elo_grad/bivariate.py
+++ b/src/elo_grad/bivariate.py
@@ -13,7 +13,7 @@ class BivariateModel(BaseModel, abc.ABC):
     def __init__(
         self,
         beta: float,
-        default_init_rating: Tuple[float, float],
+        default_init_rating: Tuple[float, Optional[float]],
         init_ratings: Optional[Dict[str, Tuple[Optional[int], float, Optional[float]]]] = None,
     ) -> None:
         super().__init__(beta)
@@ -25,19 +25,33 @@ class BivariateModel(BaseModel, abc.ABC):
             self.ratings = self.ratings | self.init_ratings
 
     @abc.abstractmethod
-    def calculate_params(self, *args) -> Tuple[float, ...]:
+    def calculate_params(
+        self,
+        args: Tuple[Tuple[float, ...], Tuple[float, ...], Tuple[float, ...]],
+    ) -> Tuple[float, float, float]:
         ...
 
     @abc.abstractmethod
-    def calculate_gradient_from_params(self, y: Tuple[int, int], params: Tuple[float, ...]) -> Tuple[float, ...]:
+    def calculate_gradient_from_params(
+        self,
+        y: Tuple[int, int],
+        params: Tuple[float, float, float],
+    ) -> Tuple[float, float]:
         ...
 
     @abc.abstractmethod
-    def calculate_expected_scores(self, *args) -> Tuple[float, float]:
+    def calculate_expected_scores(
+        self,
+        args: Tuple[Tuple[float, ...], Tuple[float, ...], Tuple[float, ...]],
+    ) -> Tuple[float, float]:
         ...
 
     @abc.abstractmethod
-    def calculate_gradient(self, y: Tuple[int, int], *args) -> Tuple[float, ...]:
+    def calculate_gradient(
+        self,
+        y: Tuple[int, int],
+        args: Tuple[Tuple[float, ...], Tuple[float, ...], Tuple[float, ...]],
+    ) -> Tuple[float, float]:
         ...
 
 
@@ -61,7 +75,7 @@ class BivariateOptimizer(BaseOptimizer, abc.ABC):
         entity_2: str,
         regressor_values: Optional[Tuple[float, ...]],
         corr_regressor_values: Optional[Tuple[float, ...]],
-        params: Optional[Tuple[float, ...]],
+        params: Optional[Tuple[float, float, float]],
     ) -> Generator[Tuple[float, ...], None, None]:
         ...
 
@@ -70,14 +84,17 @@ class BivariatePoissonRegression(BivariateModel):
 
     # We should make maxsize configurable
     @lru_cache(maxsize=512)
-    def calculate_params(self, *args) -> Tuple[float, ...]:
-        return tuple(
+    def calculate_params(
+        self,
+        args: Tuple[Tuple[float, ...], Tuple[float, ...], Tuple[float, ...]],
+    ) -> Tuple[float, float, float]:
+        return tuple(  # type:ignore
             math.pow(10, sum(a) / (2 * self.beta)) for a in args
         )
 
     @staticmethod
     @lru_cache(maxsize=512)
-    def _calculate_s(y: Tuple[int, int], k: int, params: Tuple[float, ...]) -> float:
+    def _calculate_s(y: Tuple[int, int], k: int, params: Tuple[float, float, float]) -> float:
         return (
             (params[2] / math.factorial(k))
             * ((params[0] ** (y[0] - k)) / (y[0] - k))
@@ -87,7 +104,7 @@ class BivariatePoissonRegression(BivariateModel):
     def _calculate_modified_y(
         self,
         y: Tuple[int, int],
-        params: Tuple[float, ...],
+        params: Tuple[float, float, float],
         i: int,
     ) -> float:
         if i < 0 or i > 2:
@@ -110,19 +127,30 @@ class BivariatePoissonRegression(BivariateModel):
             / norm
         )
 
-    def calculate_gradient_from_params(self, y: Tuple[int, int], params: Tuple[float, ...]) -> Tuple[float, ...]:
-        return tuple(
+    def calculate_gradient_from_params(
+        self,
+        y: Tuple[int, int],
+        params: Tuple[float, float, float],
+    ) -> Tuple[float, float]:
+        return tuple(  # type:ignore
             self._calculate_modified_y(y, params, i=i) - params[i] for i in range(2)
         )
 
-    def calculate_gradient(self, y: Tuple[int, int], *args) -> Tuple[float, ...]:
-        params: Tuple[float, ...] = self.calculate_params(*args)
-        grad: Tuple[float, ...] = self.calculate_gradient_from_params(y, params)
+    def calculate_gradient(
+        self,
+        y: Tuple[int, int],
+        args: Tuple[Tuple[float, ...], Tuple[float, ...], Tuple[float, ...]],
+    ) -> Tuple[float, float]:
+        params: Tuple[float, float, float] = self.calculate_params(args)
+        grad: Tuple[float, float] = self.calculate_gradient_from_params(y, params)
 
         return grad
 
-    def calculate_expected_scores(self, *args) -> Tuple[float, float]:
-        params = self.calculate_params(*args)
+    def calculate_expected_scores(
+        self,
+        args: Tuple[Tuple[float, ...], Tuple[float, ...], Tuple[float, ...]],
+    ) -> Tuple[float, float]:
+        params = self.calculate_params(args)
         return (
             params[0] + params[2],
             params[1] + params[2],
@@ -139,41 +167,38 @@ class BivariateSGDOptimizer(BivariateOptimizer):
         entity_2: str,
         regressor_values: Optional[Tuple[float, ...]],
         corr_regressor_values: Optional[Tuple[float, ...]],
-        params: Optional[Tuple[float, ...]],
+        params: Optional[Tuple[float, float, float]],
     ) -> Generator[Tuple[float, ...], None, None]:
         if params is not None:
             # If we already know the params, we shouldn't recalculate them
             entity_grad: Tuple[float, ...] = model.calculate_gradient_from_params(y, params)
         else:
-            regressor_contrib_1, regressor_contrib_2 = 0.0, 0.0
+            regressor_contrib: Tuple[float, float, float] = (0.0, 0.0, 0.0)
             if self.regressors is not None:
-                regressor_contribs: Generator[Tuple[float, float], None, None] = (
-                    (model.ratings[r.name][1] * v, model.ratings[r.name][1] * (1 - v))
-                    for r, v in zip(self.regressors, regressor_values)  # type:ignore
-                )
-                for c1, c2 in regressor_contribs:
-                    regressor_contrib_1 += c1
-                    regressor_contrib_2 += c2
-
-            corr_regressor_contrib: float = 0.0
-            if self.corr_regressors is not None:
-                corr_regressor_contrib = sum(
-                    model.ratings[r.name][1] * v for r, v in zip(self.corr_regressors, corr_regressor_values)  # type:ignore
+                regressor_contrib = tuple(  # type:ignore
+                    sum(
+                        model.ratings[r.name][1] * v
+                        for r, v in zip(reg, reg_val)  # type:ignore
+                    ) if reg is not None  # type:ignore
+                    else 0.0
+                    for reg, reg_val in zip(self.regressors, regressor_values)  # type:ignore
                 )
 
             entity_grad = model.calculate_gradient(
                 y,
-                (
-                    model.ratings[entity_1][1],
-                    -model.ratings[entity_2][2],  # type:ignore
-                    regressor_contrib_1,
-                ),
-                (
-                    model.ratings[entity_2][1],
-                    -model.ratings[entity_1][2],  # type:ignore
-                    regressor_contrib_2,
-                ),
-                (corr_regressor_contrib,),  # To handle correlation
+                args=(
+                    (
+                        model.ratings[entity_1][1],
+                        -model.ratings[entity_2][2],  # type:ignore
+                        regressor_contrib[0],
+                    ),
+                    (
+                        model.ratings[entity_2][1],
+                        -model.ratings[entity_1][2],  # type:ignore
+                        regressor_contrib[1],
+                    ),
+                    (regressor_contrib[2],),  # To handle correlation
+                )
             )
 
         yield tuple(self.k_factor * g for g in entity_grad)


### PR DESCRIPTION
We were leaving the lengths of tuples ambgiuous, which isn't the case and is less clear.